### PR TITLE
Update plugin to be installable on 2021.3 EAP builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.2.0-beta
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 211
-pluginUntilBuild = 212.*
+pluginUntilBuild = 213.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.


### PR DESCRIPTION
Currently running 2021.3 EAP as my daily driver IDE and wanted to test out the plugin, requiring me to change this property. Haven't checked out the changelog yet to see if any other APIs need changing.