### PR TITLE
Respect project setup environmental variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Intellij-ginkgo Changelog
 
 ## [Unreleased]
+## [0.2.1]
 ### Fixed
 - Run configuration from project settings not being respected
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Intellij-ginkgo Changelog
 
 ## [Unreleased]
+### Fixed
+- Run configuration from project settings not being respected
+
 ## [0.2.0]
 ### Added
 - Pending spec markers with action to enable/disable

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.intellij.ginkgo
 pluginName = Intellij-Ginkgo
-pluginVersion = 0.2.0
+pluginVersion = 0.2.1
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.


### PR DESCRIPTION
Environment variables configured for the project under go -> project ->
modules Environment will now be used when creating the commandline
runner
[#29]