### PR TITLE
Update runLineMarker with test status icon

### DIFF
--- a/src/main/java/com/github/idea/ginkgo/GinkgoRunConfigurationProducer.java
+++ b/src/main/java/com/github/idea/ginkgo/GinkgoRunConfigurationProducer.java
@@ -59,7 +59,7 @@ public class GinkgoRunConfigurationProducer extends LazyRunConfigurationProducer
     }
 
     private List<String> getSpecNames(ConfigurationContext context) {
-        return GinkgoUtil.getSpecNames(context.getPsiLocation());
+        return GinkgoUtil.getSpecNames(context.getPsiLocation(), true);
     }
 
     @NotNull

--- a/src/main/java/com/github/idea/ginkgo/GinkgoRunConfigurationProducer.java
+++ b/src/main/java/com/github/idea/ginkgo/GinkgoRunConfigurationProducer.java
@@ -1,6 +1,7 @@
 package com.github.idea.ginkgo;
 
 import com.github.idea.ginkgo.scope.GinkgoScope;
+import com.github.idea.ginkgo.util.GinkgoUtil;
 import com.goide.psi.GoCallExpr;
 import com.goide.psi.GoFile;
 import com.intellij.execution.actions.ConfigurationContext;
@@ -58,25 +59,7 @@ public class GinkgoRunConfigurationProducer extends LazyRunConfigurationProducer
     }
 
     private List<String> getSpecNames(ConfigurationContext context) {
-        Deque<String> specTree = new ArrayDeque<>();
-        PsiElement location = context.getPsiLocation();
-        while (location.getParent() != null) {
-            location = location.getParent();
-            if (location.getParent() instanceof GoCallExpr) {
-                GoCallExpr parent = (GoCallExpr) location.getParent();
-                StringBuilder nodeNameBuilder = new StringBuilder();
-
-                //Special case append when for When blocks
-                if (parent.getExpression().getText().equalsIgnoreCase(GinkgoSpecType.WHEN.specType())) {
-                    nodeNameBuilder.append(WHEN);
-                }
-
-                nodeNameBuilder.append(parent.getArgumentList().getExpressionList().get(0).getText().replace("\"", ""));
-                specTree.push(nodeNameBuilder.toString());
-            }
-        }
-
-        return specTree.isEmpty() ? Arrays.asList(GINKGO) : new ArrayList<>(specTree);
+        return GinkgoUtil.getSpecNames(context.getPsiLocation());
     }
 
     @NotNull

--- a/src/main/java/com/github/idea/ginkgo/GinkgoRunLineMarkerProvider.java
+++ b/src/main/java/com/github/idea/ginkgo/GinkgoRunLineMarkerProvider.java
@@ -8,6 +8,7 @@ import com.goide.psi.GoCallExpr;
 import com.goide.psi.GoExpression;
 import com.goide.psi.GoReferenceExpression;
 import com.goide.util.GoUtil;
+import com.intellij.execution.TestStateStorage;
 import com.intellij.execution.lineMarker.ExecutorAction;
 import com.intellij.execution.lineMarker.RunLineMarkerContributor;
 import com.intellij.icons.AllIcons;
@@ -56,9 +57,21 @@ public class GinkgoRunLineMarkerProvider extends RunLineMarkerContributor {
             }
 
             if (GinkgoUtil.isGinkgoFunction(name) && args.size() >= 2) {
+                Icon icon = AllIcons.RunConfigurations.TestState.Run;
+                if (name.equalsIgnoreCase(GinkgoSpecType.IT.specType())) {
+                    List<String> specNames = GinkgoUtil.getSpecNames(e);
+                    String specName = specNames.remove(specNames.size() - 1);
+                    String specContext = String.join(" ", specNames);
+                    String testUrl = "gotest://" + GinkgoRunConfigurationProducer.GINKGO + "#" + specContext + "/" + specName;
+                    TestStateStorage.Record record = TestStateStorage.getInstance(e.getProject()).getState(testUrl);
+                    if (record != null) {
+                        icon = getTestStateIcon(record, false);
+                    }
+                }
+
                 AnAction[] runActions = ExecutorAction.getActions(0);
                 runActions = ArrayUtil.append(runActions, ActionManager.getInstance().getAction("GinkgoDisableSpec"));
-                return new Info(AllIcons.RunConfigurations.TestState.Run, TOOLTIP_PROVIDER, runActions);
+                return new Info(icon, TOOLTIP_PROVIDER, runActions);
             }
 
             if (GinkgoUtil.isGinkgoPendingFunction(name)) {

--- a/src/main/java/com/github/idea/ginkgo/GinkgoRunLineMarkerProvider.java
+++ b/src/main/java/com/github/idea/ginkgo/GinkgoRunLineMarkerProvider.java
@@ -59,7 +59,7 @@ public class GinkgoRunLineMarkerProvider extends RunLineMarkerContributor {
             if (GinkgoUtil.isGinkgoFunction(name) && args.size() >= 2) {
                 Icon icon = AllIcons.RunConfigurations.TestState.Run;
                 if (name.equalsIgnoreCase(GinkgoSpecType.IT.specType())) {
-                    List<String> specNames = GinkgoUtil.getSpecNames(e);
+                    List<String> specNames = GinkgoUtil.getSpecNames(e, false);
                     String specName = specNames.remove(specNames.size() - 1);
                     String specContext = String.join(" ", specNames);
                     String testUrl = "gotest://" + GinkgoRunConfigurationProducer.GINKGO + "#" + specContext + "/" + specName;

--- a/src/main/java/com/github/idea/ginkgo/util/GinkgoUtil.java
+++ b/src/main/java/com/github/idea/ginkgo/util/GinkgoUtil.java
@@ -15,7 +15,7 @@ public class GinkgoUtil {
     private GinkgoUtil() {
         //Util class should not be instantiated.
     }
-    public static List<String> getSpecNames(@Nullable PsiElement location) {
+    public static List<String> getSpecNames(@Nullable PsiElement location, boolean appendWhen) {
         Deque<String> specTree = new ArrayDeque<>();
         while (location != null && location.getParent() != null) {
             location = location.getParent();
@@ -24,7 +24,7 @@ public class GinkgoUtil {
                 StringBuilder nodeNameBuilder = new StringBuilder();
 
                 //Special case append when for When blocks
-                if (parent.getExpression().getText().equalsIgnoreCase(GinkgoSpecType.WHEN.specType())) {
+                if (appendWhen && parent.getExpression().getText().equalsIgnoreCase(GinkgoSpecType.WHEN.specType())) {
                     nodeNameBuilder.append(GinkgoRunConfigurationProducer.WHEN);
                 }
 

--- a/src/main/java/com/github/idea/ginkgo/util/GinkgoUtil.java
+++ b/src/main/java/com/github/idea/ginkgo/util/GinkgoUtil.java
@@ -1,15 +1,39 @@
 package com.github.idea.ginkgo.util;
 
 import com.github.idea.ginkgo.GinkgoPendingSpecType;
+import com.github.idea.ginkgo.GinkgoRunConfigurationProducer;
 import com.github.idea.ginkgo.GinkgoSpecType;
 import com.github.idea.ginkgo.GinkgoTestSetupType;
+import com.goide.psi.GoCallExpr;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
+import java.util.*;
 
 public class GinkgoUtil {
 
     private GinkgoUtil() {
         //Util class should not be instantiated.
+    }
+    public static List<String> getSpecNames(@Nullable PsiElement location) {
+        Deque<String> specTree = new ArrayDeque<>();
+        while (location != null && location.getParent() != null) {
+            location = location.getParent();
+            if (location.getParent() instanceof GoCallExpr) {
+                GoCallExpr parent = (GoCallExpr) location.getParent();
+                StringBuilder nodeNameBuilder = new StringBuilder();
+
+                //Special case append when for When blocks
+                if (parent.getExpression().getText().equalsIgnoreCase(GinkgoSpecType.WHEN.specType())) {
+                    nodeNameBuilder.append(GinkgoRunConfigurationProducer.WHEN);
+                }
+
+                nodeNameBuilder.append(parent.getArgumentList().getExpressionList().get(0).getText().replace("\"", ""));
+                specTree.push(nodeNameBuilder.toString());
+            }
+        }
+
+        return specTree.isEmpty() ? Arrays.asList(GinkgoRunConfigurationProducer.GINKGO) : new ArrayList<>(specTree);
     }
 
     public static boolean isGinkgoTestSetup(String name) {


### PR DESCRIPTION
Update runLineMarker with test status icon

Note that failed tests do not display a failed icon (at least in testing with Ginkgo v2) due to them having a 'terminated' instead of 'failed' state.

**Screenshot**
![Screen Shot 2022-04-22 at 4 13 35 pm](https://user-images.githubusercontent.com/153219/164614468-bab0e2d0-cc65-4590-82b2-f7af26519c6d.png)

