### PR TITLE
fix for empty breadcrumbs in non-ginkgo go files

### DIFF
--- a/src/main/java/com/github/idea/ginkgo/GinkgoBreadcrumbsProvider.java
+++ b/src/main/java/com/github/idea/ginkgo/GinkgoBreadcrumbsProvider.java
@@ -2,6 +2,7 @@ package com.github.idea.ginkgo;
 
 import com.github.idea.ginkgo.util.GinkgoUtil;
 import com.goide.GoLanguage;
+import com.goide.editor.GoBreadcrumbsProvider;
 import com.goide.psi.GoCallExpr;
 import com.intellij.icons.AllIcons;
 import com.intellij.lang.Language;
@@ -23,6 +24,8 @@ import static com.github.idea.ginkgo.icons.GinkgoIcons.DISABLE_SPEC_ICON;
 public class GinkgoBreadcrumbsProvider implements BreadcrumbsProvider {
     private static final Language[] LANGUAGES = {GoLanguage.INSTANCE};
 
+    private final BreadcrumbsProvider defaultProvider = new GoBreadcrumbsProvider();
+
     @Override
     public Language[] getLanguages() {
         return LANGUAGES;
@@ -30,12 +33,18 @@ public class GinkgoBreadcrumbsProvider implements BreadcrumbsProvider {
 
     @Override
     public boolean acceptElement(@NotNull PsiElement e) {
+        if (!GinkgoUtil.isGinkgoTestFile(e.getContainingFile())) {
+            return this.defaultProvider.acceptElement(e);
+        }
         GinkgoExpression ginkgoExpression = getGinkgoExpression(e);
         return ginkgoExpression.isValid();
     }
 
     @Override
     public @NotNull @NlsSafe String getElementInfo(@NotNull PsiElement e) {
+        if (!GinkgoUtil.isGinkgoTestFile(e.getContainingFile())) {
+            return this.defaultProvider.getElementInfo(e);
+        }
         GinkgoExpression ginkgoExpression = getGinkgoExpression(e);
         if (!ginkgoExpression.isValid()) {
             return "";
@@ -50,7 +59,7 @@ public class GinkgoBreadcrumbsProvider implements BreadcrumbsProvider {
     public @Nullable Icon getElementIcon(@NotNull PsiElement e) {
         PsiFile file = e.getContainingFile();
         if (!GinkgoUtil.isGinkgoTestFile(file)) {
-            return null;
+            return this.defaultProvider.getElementIcon(e);
         }
 
         GinkgoExpression ginkgoExpression = getGinkgoExpression(e);

--- a/src/test/java/com/github/idea/ginkgo/GinkgoBreadcrumbsProviderTest.java
+++ b/src/test/java/com/github/idea/ginkgo/GinkgoBreadcrumbsProviderTest.java
@@ -3,6 +3,7 @@ package com.github.idea.ginkgo;
 import com.goide.GoLanguage;
 import com.goide.psi.GoCallExpr;
 import com.goide.psi.GoFile;
+import com.goide.psi.GoStructType;
 import com.intellij.icons.AllIcons;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -15,6 +16,7 @@ import org.junit.runners.JUnit4;
 
 import javax.swing.*;
 import java.util.Arrays;
+import java.util.Objects;
 
 import static com.github.idea.ginkgo.icons.GinkgoIcons.DISABLED_TEST_ICON;
 
@@ -53,6 +55,9 @@ public class GinkgoBreadcrumbsProviderTest extends BasePlatformTestCase {
         acceptsElement(file, "FIt");
         acceptsElement(file, "FEntry");
         acceptsElement(file, "FSpecify");
+
+        GoFile nonTestFile = (GoFile) myFixture.configureByFile("go_file.go");
+        assertTrue(ginkgoBreadcrumbsProvider.acceptElement(getStructFieldElement(nonTestFile, "Title")));
     }
 
     private void acceptsElement(GoFile file, String spec) {
@@ -74,6 +79,9 @@ public class GinkgoBreadcrumbsProviderTest extends BasePlatformTestCase {
         assertReturnsDescription(file, "FIt", "FIt it should be true");
         assertReturnsDescription(file, "FEntry", "FEntry true");
         assertReturnsDescription(file, "FSpecify", "FSpecify specify true");
+
+        GoFile nonTestFile = (GoFile) myFixture.configureByFile("go_file.go");
+        assertEquals("Title: string", ginkgoBreadcrumbsProvider.getElementInfo(getStructFieldElement(nonTestFile, "Title")));
     }
 
     private void assertReturnsDescription(GoFile file, String spec, String expected) {
@@ -116,5 +124,12 @@ public class GinkgoBreadcrumbsProviderTest extends BasePlatformTestCase {
                 .filter(e-> specType.equals(e.getExpression().getText()))
                 .findFirst()
                 .orElseThrow(()->new AssertionFailedError(String.format("Not found: %s", specType)));
+    }
+
+    private @NotNull PsiElement getStructFieldElement(GoFile file, String fieldName) {
+        return PsiTreeUtil.findChildrenOfType(file, GoStructType.class).stream()
+                .flatMap(e-> e.getFieldDefinitions().stream().filter(f -> Objects.equals(f.getName(), fieldName)) )
+                .findFirst()
+                .orElseThrow(()->new AssertionFailedError(String.format("Not found: %s", fieldName)));
     }
 }


### PR DESCRIPTION
Intellij expects a single `BreadcrumbsProvider` per language, so `GinkgoBreadcrumbsProvider` needs to support non-ginkgo go files.